### PR TITLE
fix: mockWebxdc: set Content-Type header to fix strict-MIME block in proxied environments

### DIFF
--- a/src/mock-webxdc.js
+++ b/src/mock-webxdc.js
@@ -10,6 +10,7 @@ export function mockWebxdc(
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
         if (req.url === "/webxdc.js") {
+          res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
           res.end(scriptSrc);
         } else {
           next();


### PR DESCRIPTION
`res.end(src)` without a Content-Type header causes browsers to see an empty MIME type. Under strict-MIME checking (GitHub Codespaces reverse proxy, nginx with `X-Content-Type-Options: nosniff`) the script is blocked with ERR_BLOCKED_BY_RESPONSE and `window.webxdc` is never set. Fix: add `res.setHeader('Content-Type', 'application/javascript; charset=utf-8')` before `res.end()` in `configureServer`. No behaviour change on localhost. Reproduces reliably in any GitHub Codespace — open the app via the forwarded-port URL and check the console.

Disclaimer: This commit was generated by the LLM Claude Sonnet 4.6. I verified myself both that it works and that this is the correct solution.